### PR TITLE
fix `wearupdate` event no player bug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,7 @@ export default e => {
   
   let wearing = false;
   useWear(e => {
-    const {wear} = e;
+    const {wear, player} = e;
     if (bowApp) {
       /* bowApp.position.copy(app.position);
       bowApp.scale.copy(app.scale);
@@ -271,6 +271,7 @@ export default e => {
       
       bowApp.dispatchEvent({
         type: 'wearupdate',
+        player,
         wear,
       });
     }


### PR DESCRIPTION
Currently in `app` repo's `z-targeting` branch, if use bow, will cause `player undefined` error:

![image](https://user-images.githubusercontent.com/10785634/169096181-128917b5-ce5e-48aa-bd2a-8cff1dbdeb72.png)

Should due to this change https://github.com/webaverse/app/commit/fe8a14b1dc283a649e81c919c59c5d6e5a593fae
So added `player` to `wearupdate` event to fix.
Tested that works fine, and still works fine with `app` repo's `master` branch too.