### PR TITLE
Consider `targetApp`'s `vincibility`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ export default e => {
             {
               const collisionId = collision.objectId;
               const object = getAppByPhysicsId(collisionId);
-              if (object) {
+              if (object && object.getComponent('vincibility') !== 'invincible') {
                 const damage = 10;
                 const hitDirection = localVector4.set(0, 0, -1)
                   .applyQuaternion(arrowApp.quaternion);


### PR DESCRIPTION
Fix: https://github.com/webaverse/app/issues/3062
Follow: https://github.com/webaverse/app/pull/2965#issuecomment-1122910600

- Consider `targetApp`'s `vincibility`, prevent damage with `vincibility: invincible`, such as ground and building.